### PR TITLE
Removed Cat

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "first steps with node",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/qunit/bin/cli.js -c index.js -t test.js | cat"
+    "test": "node ./node_modules/qunit/bin/cli.js -c index.js -t test.js"
   },
   "keywords": [
     "node"


### PR DESCRIPTION
Removed cat from package.json due to the fact that with "cat" it breaks on windows as "cat" is not a recognised command in CMD and in Powershell its an alias (seemingly) for Get-Content
Removing it allows it to work on Windows without fail and it still pipes the output to console as shown below.
![image](https://user-images.githubusercontent.com/24227350/48354816-8a010c80-e68a-11e8-8a6d-68d759ec27a9.png)
